### PR TITLE
Updated StratCon SP/CVP Buttons to Use GM Mode Check

### DIFF
--- a/MekHQ/src/mekhq/gui/stratcon/CampaignManagementDialog.java
+++ b/MekHQ/src/mekhq/gui/stratcon/CampaignManagementDialog.java
@@ -71,8 +71,8 @@ public class CampaignManagementDialog extends JDialog {
                         StratconTrackState currentTrack, boolean gmMode) {
         currentCampaignState = campaignState;
 
-        btnRemoveCVP.setEnabled(currentCampaignState.getVictoryPoints() > 0);
-        btnGMRemoveSP.setEnabled(currentCampaignState.getSupportPoints() > 0);
+        btnRemoveCVP.setEnabled(gmMode);
+        btnGMRemoveSP.setEnabled(gmMode);
         btnGMAddVP.setEnabled(gmMode);
         btnGMAddSP.setEnabled(gmMode);
 


### PR DESCRIPTION
- Changed `btnRemoveCVP` and `btnGMRemoveSP` to enable based on `gmMode` instead of point counts.
- Ensured consistency in button enabling logic for GM mode in the Campaign Management Dialog.

### Dev Notes
This PR just ensures these buttons are only usable while in GM mode. I also removed the need for the player to have positive CVP/SP before the GM can remove, as both of these values can reasonably be in the negative (less SP, but I can still see a use case).